### PR TITLE
Add openfast floating linear case to reg tests

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -119,6 +119,7 @@ of_regression_linear("WP_Stationary_Linear"         "openfast;linear;elastodyn;a
 of_regression_linear("Ideal_Beam_Fixed_Free_Linear" "openfast;linear;beamdyn")
 of_regression_linear("Ideal_Beam_Free_Free_Linear"  "openfast;linear;beamdyn")
 of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;servodyn")
+of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn")
 
 # BeamDyn regression tests
 bd_regression("bd_5MW_dynamic"            "beamdyn;dynamic")


### PR DESCRIPTION
I'm working with @jjonkman and @nickjohnson13 to incorporate an OpenFAST floating linearization case into the regression tests. This pull request is *not yet* ready to merge, but can serve as a place for general communication in this effort.